### PR TITLE
头脑王者添加ios支持

### DIFF
--- a/头脑王者/src/robot.js
+++ b/头脑王者/src/robot.js
@@ -4,6 +4,12 @@ const QuizModel = require('./database/quiz-model')
 
 // AngProxy 只支持 yield 语法，暂不支持 await
 module.exports = {
+  * beforeDealHttpsRequest(requestDetail) {
+    if (requestDetail.host.indexOf('question.hortor.net') !== -1) {
+      return true;
+    }
+    return false;
+  },
   * beforeSendRequest (requestDetail) {
     // 原先采用的是改数据发送，经测试发现会频繁的提示需要重新登录，所以改为只提示答案了
   },

--- a/头脑王者/src/robot.js
+++ b/头脑王者/src/robot.js
@@ -8,6 +8,9 @@ module.exports = {
     if (requestDetail.host.indexOf('question.hortor.net') !== -1) {
       return true;
     }
+    if (requestDetail.host.indexOf('question-zh.hortor.net') !== -1) {
+      return true;
+    }
     return false;
   },
   * beforeSendRequest (requestDetail) {


### PR DESCRIPTION
anyproxy不支持wss协议，所以需要添加https过滤规则

添加过滤规则后可以在ios下使用
